### PR TITLE
Fix for paths starting with any character from "would reformat"

### DIFF
--- a/src/black_gl_code_quality/parser.py
+++ b/src/black_gl_code_quality/parser.py
@@ -10,7 +10,7 @@ def parse_simple_mode(data: List[str], severity: str) -> Sequence[Mapping[str, A
 
     for line in data:
         if line.startswith(magic_word):
-            path = Path(line.strip(magic_word).strip()).relative_to(Path.cwd())
+            path = Path(line.removeprefix(magic_word).strip()).relative_to(Path.cwd())
             errors.append(generate_error(str(path), severity))
 
     return errors


### PR DESCRIPTION
I ran into this issue while trying to integrate this in my company's CI: many python files are inside a directory called `app`, and when running `black-gl-code-quality` the output paths would end up as `pp/main.py`. It looks like this is happening because .strip() will remove *the character set* specified in its argument, rather than a contiguous string, so the `a` in `would reformat` causes the space after `would reformat ...` and the `a` from `app/` to also be removed. This should fix that issue.